### PR TITLE
fix(timeupdate): Trigger `ended` event when clip reaches the end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ node_modules/
 
 # Build-related directories
 dist/
-
+docs/api/
+test/dist/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) Carles Galan Cladera &lt;cgcladera@gmail.com&gt;
+Copyright (c) Carles Galan Cladera <cgcladera@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [videojs-offset](#videojs-offset)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [`<script>` Tag](#script-tag)
+    - [Browserify](#browserify)
+    - [RequireJS/AMD](#requirejsamd)
+  - [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # videojs-offset
 
 [![Build Status](https://travis-ci.org/cladera/videojs-offset.svg?branch=master)](https://travis-ci.org/cladera/videojs-offset)

--- a/index.html
+++ b/index.html
@@ -22,7 +22,12 @@
       var player = window.player = videojs('videojs-offset-player');
 
       player.offset({
+        start: 5,
         end: 30
+      });
+
+      player.on('ended', () => {
+        console.log('clip ended');
       });
     }(window, window.videojs));
   </script>

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["plugins/markdown"]
+}

--- a/package.json
+++ b/package.json
@@ -2,23 +2,44 @@
   "name": "videojs-offset",
   "version": "2.0.0-beta.0",
   "description": "VideoJs plugin to virtually \"cut\" an ondemand video",
-  "main": "dist/es5/index.js",
+  "main": "dist/videojs-offset.cjs.js",
   "jsnext:main": "src/js/index.js",
   "engines": {
     "node": ">=4.4.0"
   },
   "generator-videojs-plugin": {
-    "version": "3.1.1"
+    "version": "5.0.0"
   },
   "scripts": {
-    "build": "sb-build",
-    "clean": "sb-clean",
-    "lint": "sb-lint",
-    "start": "sb-start",
-    "test": "sb-test",
-    "watch": "sb-watch",
+    "prebuild": "npm run clean",
+    "build": "npm-run-all -p build:*",
+    "build:js": "npm-run-all build:js:rollup-modules build:js:rollup-umd build:js:bannerize build:js:uglify",
+    "build:js:bannerize": "bannerize dist/videojs-offset.js --banner=scripts/banner.ejs",
+    "build:js:rollup-modules": "rollup -c scripts/modules.rollup.config.js",
+    "build:js:rollup-umd": "rollup -c scripts/umd.rollup.config.js",
+    "build:js:uglify": "uglifyjs dist/videojs-offset.js --comments --mangle --compress --ie8 -o dist/videojs-offset.min.js",
+    "build:test": "rollup -c scripts/test.rollup.config.js",
+    "clean": "rimraf dist test/dist",
+    "postclean": "mkdirp dist test/dist",
+    "docs": "npm-run-all docs:*",
+    "docs:api": "jsdoc src -r -c jsdoc.json -d docs/api",
+    "docs:toc": "doctoc README.md",
+    "lint": "vjsstandard",
+    "prestart": "npm run build",
+    "start": "npm-run-all -p start:server watch",
+    "start:server": "static -a 0.0.0.0 -p 9999 -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}' .",
+    "pretest": "npm-run-all lint build",
+    "test": "karma start test/karma.conf.js",
+    "preversion": "npm test",
+    "version": "node scripts/version.js",
+    "postversion": "sb-release",
+    "watch": "npm-run-all -p watch:*",
+    "watch:js-modules": "rollup -c scripts/modules.rollup.config.js -w",
+    "watch:js-umd": "rollup -c scripts/umd.rollup.config.js -w",
+    "watch:test": "rollup -c scripts/test.rollup.config.js -w",
     "prepublish": "npm run build",
-    "postversion": "sb-release"
+    "prepush": "npm run lint",
+    "precommit": "npm run docs && git add README.md"
   },
   "keywords": [
     "videojs",
@@ -33,27 +54,68 @@
     "ie8": true
   },
   "files": [
-    "CHANGELOG.md",
     "CONTRIBUTING.md",
-    "README.md",
-    "dist/browser",
-    "dist/docs",
-    "dist/es5",
-    "dist/lang",
+    "dist/",
     "docs/",
     "index.html",
-    "src/"
+    "scripts/",
+    "src/",
+    "test/"
   ],
   "dependencies": {
-    "video.js": "^5.16.0"
+    "global": "^4.3.2",
+    "video.js": "^5.19.2"
   },
   "devDependencies": {
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-es3": "^1.0.1",
+    "bannerize": "^1.0.2",
+    "conventional-changelog-cli": "^1.3.1",
+    "conventional-changelog-videojs": "^3.0.0",
+    "doctoc": "^1.3.0",
+    "es5-shim": "^4.5.9",
     "ghooks": "^1.3.2",
-    "videojs-spellbook": "^2.0.2"
+    "husky": "^0.13.3",
+    "jsdoc": "^3.4.3",
+    "karma": "~1.3.0",
+    "karma-chrome-launcher": "^2.1.1",
+    "karma-detect-browsers": "^2.2.5",
+    "karma-firefox-launcher": "^1.0.1",
+    "karma-ie-launcher": "^1.0.0",
+    "karma-qunit": "^1.2.1",
+    "karma-safari-launcher": "^1.0.0",
+    "mkdirp": "^0.5.1",
+    "node-static": "^0.7.9",
+    "npm-run-all": "^4.0.2",
+    "qunitjs": "^1.21.0",
+    "rimraf": "^2.6.1",
+    "rollup": "^0.41.6",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-json": "^2.1.1",
+    "rollup-plugin-multi-entry": "^2.0.1",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-watch": "^3.2.2",
+    "semver": "^5.3.0",
+    "sinon": "^2.2.0",
+    "uglify-js": "^3.0.7",
+    "videojs-spellbook": "^2.0.2",
+    "videojs-standard": "^6.0.0"
   },
   "config": {
     "ghooks": {
       "pre-push": "npm run test"
     }
+  },
+  "module": "dist/videojs-offset.es.js",
+  "vjsstandard": {
+    "ignore": [
+      "dist",
+      "docs",
+      "test/dist",
+      "test/karma.conf.js"
+    ]
   }
 }

--- a/scripts/banner.ejs
+++ b/scripts/banner.ejs
@@ -1,0 +1,6 @@
+/**
+ * <%- pkg.name %>
+ * @version <%- pkg.version %>
+ * @copyright <%- date.getFullYear() %> <%- pkg.author %>
+ * @license <%- pkg.license %>
+ */

--- a/scripts/modules.rollup.config.js
+++ b/scripts/modules.rollup.config.js
@@ -1,0 +1,41 @@
+/**
+ * Rollup configuration for packaging the plugin in a module that is consumable
+ * by either CommonJS (e.g. Node or Browserify) or ECMAScript (e.g. Rollup).
+ *
+ * These modules DO NOT include their dependencies as we expect those to be
+ * handled by the module system.
+ */
+import babel from 'rollup-plugin-babel';
+import json from 'rollup-plugin-json';
+
+export default {
+  moduleName: 'videojsOffset',
+  entry: 'src/plugin.js',
+  external: ['video.js'],
+  globals: {
+    'video.js': 'videojs'
+  },
+  legacy: true,
+  plugins: [
+    json(),
+    babel({
+      babelrc: false,
+      exclude: 'node_modules/**',
+      presets: [
+        'es3',
+        ['es2015', {
+          loose: true,
+          modules: false
+        }]
+      ],
+      plugins: [
+        'external-helpers',
+        'transform-object-assign'
+      ]
+    })
+  ],
+  targets: [
+    {dest: 'dist/videojs-offset.cjs.js', format: 'cjs'},
+    {dest: 'dist/videojs-offset.es.js', format: 'es'}
+  ]
+};

--- a/scripts/test.rollup.config.js
+++ b/scripts/test.rollup.config.js
@@ -1,0 +1,59 @@
+/**
+ * Rollup configuration for packaging the plugin in a test bundle.
+ *
+ * This includes all dependencies for both the plugin and its tests.
+ */
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import json from 'rollup-plugin-json';
+import multiEntry from 'rollup-plugin-multi-entry';
+import resolve from 'rollup-plugin-node-resolve';
+
+export default {
+  moduleName: 'videojsOffsetTests',
+  entry: 'test/**/*.test.js',
+  dest: 'test/dist/bundle.js',
+  format: 'iife',
+  external: [
+    'qunit',
+    'qunitjs',
+    'sinon',
+    'video.js'
+  ],
+  globals: {
+    'qunit': 'QUnit',
+    'qunitjs': 'QUnit',
+    'sinon': 'sinon',
+    'video.js': 'videojs'
+  },
+  legacy: true,
+  plugins: [
+    multiEntry({
+      exports: false
+    }),
+    resolve({
+      browser: true,
+      main: true,
+      jsnext: true
+    }),
+    json(),
+    commonjs({
+      sourceMap: false
+    }),
+    babel({
+      babelrc: false,
+      exclude: 'node_modules/**',
+      presets: [
+        'es3',
+        ['es2015', {
+          loose: true,
+          modules: false
+        }]
+      ],
+      plugins: [
+        'external-helpers',
+        'transform-object-assign'
+      ]
+    })
+  ]
+};

--- a/scripts/umd.rollup.config.js
+++ b/scripts/umd.rollup.config.js
@@ -1,0 +1,48 @@
+/**
+ * Rollup configuration for packaging the plugin in a module that is consumable
+ * as the `src` of a `script` tag or via AMD or similar client-side loading.
+ *
+ * This module DOES include its dependencies.
+ */
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import json from 'rollup-plugin-json';
+import resolve from 'rollup-plugin-node-resolve';
+
+export default {
+  moduleName: 'videojsOffset',
+  entry: 'src/plugin.js',
+  dest: 'dist/videojs-offset.js',
+  format: 'umd',
+  external: ['video.js'],
+  globals: {
+    'video.js': 'videojs'
+  },
+  legacy: true,
+  plugins: [
+    resolve({
+      browser: true,
+      main: true,
+      jsnext: true
+    }),
+    json(),
+    commonjs({
+      sourceMap: false
+    }),
+    babel({
+      babelrc: false,
+      exclude: 'node_modules/**',
+      presets: [
+        'es3',
+        ['es2015', {
+          loose: true,
+          modules: false
+        }]
+      ],
+      plugins: [
+        // 'external-helpers',
+        'transform-object-assign'
+      ]
+    })
+  ]
+};

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,0 +1,10 @@
+const execSync = require('child_process').execSync;
+const path = require('path');
+const semver = require('semver');
+const pkg = require('../package.json');
+
+if (!semver.prerelease(pkg.version)) {
+  process.chdir(path.resolve(__dirname, '..'));
+  execSync('conventional-changelog -p videojs -i CHANGELOG.md -s');
+  execSync('git add CHANGELOG.md');
+}

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>videojs-offset Unit Tests</title>
+  <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
+  <link rel="stylesheet" href="../node_modules/video.js/dist/video-js.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <script src="../node_modules/es5-shim/es5-shim.js"></script>
+  <script src="../node_modules/sinon/pkg/sinon.js"></script>
+  <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
+  <script src="../test/dist/bundle.js"></script>
+</body>
+</html>

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,45 @@
+module.exports = function(config) {
+  var detectBrowsers = {
+    enabled: false,
+    usePhantomJS: false
+  };
+
+  config.browsers = ['Chrome'];
+
+  // On Travis CI, we can only run in Firefox and Chrome; so, enforce that.
+  if (process.env.TRAVIS) {
+    config.browsers = ['Firefox', 'travisChrome'];
+  }
+
+  // If no browsers are specified, we enable `karma-detect-browsers`
+  // this will detect all browsers that are available for testing
+  if (!config.browsers.length) {
+    detectBrowsers.enabled = true;
+  }
+
+  config.set({
+    basePath: '..',
+    frameworks: ['qunit', 'detectBrowsers'],
+    files: [
+      'node_modules/video.js/dist/video-js.css',
+
+      'node_modules/es5-shim/es5-shim.js',
+      'node_modules/sinon/pkg/sinon.js',
+      'node_modules/video.js/dist/video.js',
+      'test/dist/bundle.js'
+    ],
+    customLaunchers: {
+      travisChrome: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
+    detectBrowsers: detectBrowsers,
+    reporters: ['dots'],
+    port: 9876,
+    colors: true,
+    autoWatch: false,
+    singleRun: true,
+    concurrency: Infinity
+  });
+};

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,14 +1,12 @@
-import {document} from 'global';
+import document from 'global/document';
 
-import QUnit from 'qunitjs';
+import QUnit from 'qunit';
 import sinon from 'sinon';
 import videojs from 'video.js';
 
-import plugin from '../src/js/index.js';
+import plugin from '../src/plugin';
 
 const Player = videojs.getComponent('Player');
-
-QUnit.module('sanity tests');
 
 QUnit.test('the environment is sane', function(assert) {
   assert.strictEqual(typeof Array.isArray, 'function', 'es5 exists');


### PR DESCRIPTION
## Description
When the media reaches the end `ended` event is triggered.

## Specific Changes proposed
- Plugin makes the player trigger 'ended' event when the media reaches the end.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
