### PR TITLE
fix: remaining time

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -94,22 +94,13 @@ const offset = function(options) {
         return Player.__super__.currentTime
           .call(this, seconds + this._offsetStart);
       }
-      const curr = Player.__super__.currentTime
-        .apply(this);
 
-      if (curr > this._offsetStart) {
-        return curr - this._offsetStart;
-      }
-      return 0;
+      return Player.__super__.currentTime
+        .apply(this) - this._offsetStart;
     };
 
     Player.prototype.remainingTime = function() {
-      let curr = this.currentTime();
-
-      if (curr < this._offsetStart) {
-        curr = 0;
-      }
-      return this.duration() - curr;
+      return this.duration() - this.currentTime();
     };
 
     Player.prototype.startOffset = function() {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -60,14 +60,27 @@ QUnit.test('registers itself with video.js', function(assert) {
   );
 });
 
-QUnit.test('configure start and end as as strings', function(assert) {
-  assert.expect(2);
+QUnit.test('remaining time', function(assert) {
+  assert.expect(1);
 
-  assert.strictEqual(
-    typeof Player.prototype.offset,
-    'function',
-    'videojs-offset plugin was registered'
+  this.player.offset({
+    start: 10,
+    end: 300
+  });
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  this.player.currentTime(2);
+
+  assert.ok(
+    this.player.remainingTime() === 288,
+    'the plugin alters remaining time'
   );
+});
+
+QUnit.test('configure start and end as as strings', function(assert) {
+  assert.expect(1);
 
   this.player.offset({
     start: '10.5',


### PR DESCRIPTION
## Description
Fix remainingTime method.

## Specific Changes proposed
As @zetisam suggested, it removes the piece of code that was checking the currentTime is less than the start offset since currentTime is already taking care of it.

## Requirements Checklist
- [x] Bug fixed
- [x] Unit Tests updated or fixed
- [x] Reviewed by Core Contributors
