### PR TITLE
Do not remove `timeupdate` handler on segment end

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -22,7 +22,6 @@ const onPlayerTimeUpdate = function() {
     this.play();
   }
   if (this._offsetEnd > 0 && curr > (this._offsetEnd - this._offsetStart)) {
-    this.off('timeupdate', onPlayerTimeUpdate);
     this.pause();
     this.trigger('ended');
 


### PR DESCRIPTION
This fixes second playback without end boundary

## Description
If the media (segment) is watched until the end and then replayed, that second time it won't pause at the `end` time provided.

## Specific Changes proposed
Removed line where the `timeupdate` handler is taken off from the player.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
