### PR TITLE
Update currentTime value in Video.js cache

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -108,8 +108,10 @@ const offset = function(options) {
       }
 
       if (this._offsetStart !== undefined) {
-        return Player.__super__.currentTime
+        const t = Player.__super__.currentTime
           .apply(this) - this._offsetStart;
+        this.getCache().currentTime = t;
+        return t;
       }
       return Player.__super__.currentTime.apply(this);
     };


### PR DESCRIPTION
fixes #43 

The source of the problem is: In Video.js, `SeekBar.getCurrentTime_()` retrieves the current video position from the cache when the player is in scrubbing mode (i.e. while the mouse button is down). The cached `currentTime` value is set at the end of `Player.currentTime()`. The videojs-offset plugin overrides `Player.currentTime()` and modifies the returned value, but the original (wrong) `currentTime` value gets cached. This patch fixes that by updating the cached value.

See:
`getCurrentTime_()` in [seek-bar.js](https://github.com/videojs/video.js/blob/main/src/js/control-bar/progress-control/seek-bar.js)
`currentTime()` in [player.js](https://github.com/videojs/video.js/blob/master/src/js/player.js)